### PR TITLE
Update printer.cfg to work again

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -184,7 +184,7 @@ shutdown_speed : 0
 
 [output_pin power]
 pin: PD0
-static_value: 1
+value: 1
 
 [mcu]
 serial:/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0


### PR DESCRIPTION
From the Klipper Docs: https://www.klipper3d.org/Config_Changes.html 20240912: Support for maximum_mcu_duration and static_value parameters in [output_pin] config sections have been removed. These options have been deprecated since 20240123. […]
20240123: The output_pin static_value parameter is deprecated. Replace with value and shutdown_value parameters. The option will be removed in the near future.